### PR TITLE
Update TextEditor.cpp

### DIFF
--- a/TextEditor.cpp
+++ b/TextEditor.cpp
@@ -2335,7 +2335,7 @@ void TextEditor::ColorizeInternal()
 						{
 							withinSingleLineComment = true;
 						}
-						else if (!withinSingleLineComment && currentIndex + startStr.size() <= line.size() &&
+						else if (startStr.size() != 0 && !withinSingleLineComment && currentIndex + startStr.size() <= line.size() &&
 							equals(startStr.begin(), startStr.end(), from, from + startStr.size(), pred))
 						{
 							commentStartLine = currentLine;


### PR DESCRIPTION
Fixed an error where all text would be detected as a multi-line comment if no start and end strings were defined. Not all languages have multi-line comments, so this is a necessary fix.